### PR TITLE
add binary for macos Intel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build-deps:
 build:
 	mkdir -p bin
 	GOARCH=amd64 GOOS=linux go build -o bin/$(BINARY_NAME)_${BUILD_NUMBER}_linux_amd64 -ldflags "-X main.BuildID=${BUILD_NUMBER}" .
+	GOARCH=amd64 GOOS=darwin go build -o bin/$(BINARY_NAME)_${BUILD_NUMBER}_macos_amd64 -ldflags "-X main.BuildID=${BUILD_NUMBER}" .
 
 
 install: 

--- a/changelog.md
+++ b/changelog.md
@@ -38,11 +38,21 @@ It is important to have in mind the HFI endpoint is intended to send events with
 - Use low values in `send_frequency_ms`. Expected values will be around 500 - 1500 ms.
 - Use low values in `send_bathc_size`. The HFI endopoint is not intended to be used with high data sizes so use a small number of events. In general, num_events * size_event < 
 
+### Fixes
+- Added support for [HFI](https://docs.tinybird.co/api-reference/datasource-api.html#post-v0-events-title).
+
+
+## [1.1.0] (2022-02-17)
+
+Added a new binary file for macOS (x86_64).
+
 ### Downloads
 
 * [deb package](https://storage.googleapis.com/tbtail-releases/tbtail_1.1.0_amd64.deb)
 
-* [binary file](https://storage.googleapis.com/tbtail-releases/tbtail_1.1.0_linux_amd64)
+* [binary file Linux](https://storage.googleapis.com/tbtail-releases/tbtail_1.1.0_linux_amd64)
+
+* [binary file macOS](https://storage.googleapis.com/tbtail-releases/tbtail_1.1.0_macos_amd64)
 
 ### Fixes
-- Added support for [HFI](https://docs.tinybird.co/api-reference/datasource-api.html#post-v0-events-title).
+- N/A


### PR DESCRIPTION
Added a new line into file makefile to build a new binary for macos (Intel). Finally, we couldn't to create binary for macos (arm - silicon), because this is not possible using version 1.14. You can find more information into this thread (https://github.com/golang/go/issues/38485)